### PR TITLE
Use original txn description

### DIFF
--- a/functions/plaid.ts
+++ b/functions/plaid.ts
@@ -1,11 +1,12 @@
 import {
   Configuration,
   CountryCode,
+  type LinkTokenCreateRequest,
   PlaidApi,
   PlaidEnvironments,
   Products,
-  RemovedTransaction,
-  Transaction as PlaidTransaction
+  type RemovedTransaction,
+  type Transaction as PlaidTransaction
 } from "plaid"
 import {
   createTransaction,
@@ -44,7 +45,7 @@ const configuration = new Configuration({
 const client = new PlaidApi(configuration)
 
 export async function createLinkToken(userId: string) {
-  const linkTokenConfig = {
+  const linkTokenConfig: LinkTokenCreateRequest = {
     user: {
       client_user_id: userId
     },
@@ -83,7 +84,7 @@ function convertPlaidTransactionToDatabaseTransaction(
   plaidTransaction: PlaidTransaction
 ) {
   const newTransaction: Transaction = {
-    name: plaidTransaction.name,
+    name: plaidTransaction.original_description || plaidTransaction.name,
     id: plaidTransaction.transaction_id,
     accountId: plaidTransaction.account_id,
     currencyCode: plaidTransaction.iso_currency_code || "",
@@ -117,7 +118,10 @@ export async function syncTransactions(accessToken: string) {
   while (hasMore) {
     const transactions = await client.transactionsSync({
       access_token: accessToken,
-      cursor
+      cursor,
+      options: {
+        include_original_description: true
+      }
       // TODO: add support for filtering by account_id
     })
     const data = transactions.data

--- a/prisma/migrations/20250718065524_init/migration.sql
+++ b/prisma/migrations/20250718065524_init/migration.sql
@@ -1,0 +1,76 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "image" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Item" (
+    "id" TEXT NOT NULL,
+    "accessToken" TEXT NOT NULL,
+    "encryptionKeyVersion" TEXT NOT NULL,
+    "institutionName" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Item_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "mask" TEXT,
+    "itemId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "currencyCode" TEXT NOT NULL,
+    "amount" DECIMAL(65,30) NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "pending" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Cursor" (
+    "itemId" TEXT NOT NULL,
+    "string" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Cursor_pkey" PRIMARY KEY ("itemId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Cursor" ADD CONSTRAINT "Cursor_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
When rendering transactions, prioritize the [`original_description`](https://plaid.com/docs/api/products/transactions/#transactions-sync-response-added-original-description) field over `name`